### PR TITLE
Use secrets.TRI_DEVICE_ID instead of hard-coded ID

### DIFF
--- a/.github/workflows/spotify-play-tribookpro.yml
+++ b/.github/workflows/spotify-play-tribookpro.yml
@@ -20,4 +20,4 @@ jobs:
         # Song to search for
         song: Daniel Powter - Bad Day
         # Spotify device_id (https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/)
-        device_id: b29e87a4f99813d09744e8b1d88089acdccfc60d
+        device_id: ${{ secrets.TRI_DEVICE_ID }}


### PR DESCRIPTION
This PR modifies the aptly named `spotify-play-tribookpro` / "Play Bad Day" GitHub Action to use a GitHub Actions Secret instead of a hard-coded and very, very, very public device ID.